### PR TITLE
SLING-7380 - Querying maps with Integer keys returns null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.0.14</version>
+            <version>1.0.17-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModel.java
@@ -73,10 +73,11 @@ public abstract class AbstractRuntimeObjectModel implements RuntimeObjectModel {
 
     @Override
     public Object resolveProperty(Object target, Object property) {
-        Object resolved;
+        Object resolved = null;
         if (property instanceof Number) {
             resolved = ObjectModel.getIndex(target, ((Number) property).intValue());
-        } else {
+        }
+        if (resolved == null) {
             resolved = getProperty(target, property);
         }
         return resolved;
@@ -138,7 +139,7 @@ public abstract class AbstractRuntimeObjectModel implements RuntimeObjectModel {
             result = ((Record) target).getProperty(property);
         }
         if (result == null) {
-            result = ObjectModel.resolveProperty(target, property);
+            result = ObjectModel.resolveProperty(target, propertyObj);
         }
         return result;
     }

--- a/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
@@ -16,6 +16,12 @@
  ******************************************************************************/
 package org.apache.sling.scripting.sightly.render;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -25,10 +31,33 @@ public class AbstractRuntimeObjectModelTest {
     private AbstractRuntimeObjectModel runtimeObjectModel = new AbstractRuntimeObjectModel() {};
 
     @Test
-    public void testResolveProperty_ArrayLength() throws Exception {
+    public void testResolveProperty() {
+        assertEquals(0, runtimeObjectModel.resolveProperty(Collections.EMPTY_LIST, "size"));
+        assertNull(runtimeObjectModel.resolveProperty(null, null));
         int[] ints = new int[] {1, 2, 3};
-        Integer[] integers = new Integer[] {1, 2, 3};
         assertEquals(ints.length, runtimeObjectModel.resolveProperty(ints, "length"));
-        assertEquals(integers.length, runtimeObjectModel.resolveProperty(integers, "length"));
+        Integer[] testArray = new Integer[] {1, 2, 3};
+        assertEquals(testArray.length, runtimeObjectModel.resolveProperty(testArray, "length"));
+        assertEquals(2, runtimeObjectModel.resolveProperty(testArray, 1));
+        assertNull(runtimeObjectModel.resolveProperty(testArray, 3));
+        assertNull(runtimeObjectModel.resolveProperty(testArray, -1));
+        List<Integer> testList = Arrays.asList(testArray);
+        assertEquals(2, runtimeObjectModel.resolveProperty(testList, 1));
+        assertNull(runtimeObjectModel.resolveProperty(testList, 3));
+        assertNull(runtimeObjectModel.resolveProperty(testList, -1));
+        Map<String, Integer> map = new HashMap<String, Integer>() {{
+            put("one", 1);
+            put("two", 2);
+        }};
+        assertEquals(1, runtimeObjectModel.resolveProperty(map, "one"));
+        assertNull(runtimeObjectModel.resolveProperty(map, null));
+        assertNull(runtimeObjectModel.resolveProperty(map, ""));
+        Map<Integer, String> stringMap = new HashMap<Integer, String>(){{
+            put(1, "one");
+            put(2, "two");
+        }};
+        assertEquals("one", runtimeObjectModel.resolveProperty(stringMap, 1));
+        assertEquals("two", runtimeObjectModel.resolveProperty(stringMap, 2));
     }
+
 }


### PR DESCRIPTION
* corrected object property resolution in `org.apache.sling.scripting.sightly.render.AbstractRuntimeObjectModel#resolveProperty`
and `org.apache.sling.scripting.sightly.render.AbstractRuntimeObjectModel#getProperty`